### PR TITLE
Fixed! The issues were:

### DIFF
--- a/playlist.py
+++ b/playlist.py
@@ -32,7 +32,10 @@ def extract_playlist_info(url):
                     beech_ka_array = []
                     beech_ka_array.append(f"https://www.youtube.com/watch?v={entry['id']}")
                     beech_ka_array.append(entry.get("title", "Unknown"))
-                    time = str(datetime.timedelta(seconds=entry.get("duration", 0)))
+                    duration = entry.get("duration")
+                    if duration is None:
+                        duration = 0
+                    time = str(datetime.timedelta(seconds=duration))
                     beech_ka_array.append(time)
                     final_array.append(beech_ka_array)
         #     print(final_array)
@@ -42,9 +45,7 @@ def extract_playlist_info(url):
         return playlist_title, final_array
     except Exception as e:
         logger.error(f"Failed to extract playlist: {e}")
-        return {
-            "error": str(e)
-        }
+        return None, []
     
 def extract_video_info_from_array(final_array):
     videos_dict = {}


### PR DESCRIPTION
This pull request makes small improvements to the `extract_playlist_info` function in `playlist.py`, focusing on error handling and robustness when processing playlist entries.

* Robustness improvements:
  * Ensured that the `duration` field is always an integer by explicitly checking for `None` and defaulting to zero, preventing errors when the field is missing.

* Error handling changes:
  * Updated the error return value to consistently return `None` for `playlist_title` and an empty list for `final_array` instead of a dictionary with an error message, standardizing the function's output format.

Duration handling: Some videos in the playlist don't have duration info, returning None. I added an explicit check to convert None to 0 before creating the timedelta.

Return consistency: When an exception occurred, the function returned a dict instead of a tuple, breaking the unpacking in calling code. Now it consistently returns (None, []) on error.